### PR TITLE
Tweak `civisocial_user` table structure

### DIFF
--- a/CRM/Civisocial/BAO/CivisocialUser.php
+++ b/CRM/Civisocial/BAO/CivisocialUser.php
@@ -108,13 +108,18 @@ class CRM_Civisocial_BAO_CivisocialUser {
 					$contact_id = $key;
 				}
 			}
+
+			$dateTime = date('YmdHis', time());
 			$params = array(
 				'contact_id' => $contact_id,
 				'social_user_id' => CRM_Utils_Array::value("id", $user_data_response),
 				'access_token' => $access_token,
 				'oauth_object' => CRM_Utils_Array::value("link", $user_data_response),
 				'backend' => 'facebook',
+				'created_date' => $dateTime,
+				'modified_date' => $dateTime,
 			);
+			// exit( var_dump( $params ) );
 			self::create($params);
 			return $contact_id;
 		}
@@ -149,12 +154,16 @@ class CRM_Civisocial_BAO_CivisocialUser {
 					$contact_id = $key;
 				}
 			}
+
+			$dateTime = date('Y-m-d H:i:s', time());
 			$params = array(
 				'contact_id' => $contact_id,
 				'social_user_id' => CRM_Utils_Array::value("sub", $user_data_response),
 				'access_token' => $access_token,
 				'oauth_object' => CRM_Utils_Array::value("profile", $user_data_response),
 				'backend' => 'googleplus',
+				'created_date' => $dateTime,
+				'modified_date' => $dateTime,
 			);
 			self::create($params);
 			return $contact_id;

--- a/CRM/Civisocial/DAO/CivisocialUser.php
+++ b/CRM/Civisocial/DAO/CivisocialUser.php
@@ -235,7 +235,7 @@ class CRM_Civisocial_DAO_CivisocialUser extends CRM_Core_DAO {
 				),
 				'created_date' => array(
 					'name' => 'created_date',
-					'type' => CRM_Utils_Type::T_TIMESTAMP,
+					'type' => CRM_Utils_Type::T_DATE,
 					'title' => ts('Created Date'),
 					'description' => 'When was the civisocial user was created.',
 					'required' => false,
@@ -243,11 +243,10 @@ class CRM_Civisocial_DAO_CivisocialUser extends CRM_Core_DAO {
 					'where' => 'civisocial_user.created_date',
 					'headerPattern' => '',
 					'dataPattern' => '',
-					'default' => 'CURRENT_TIMESTAMP',
 				),
 				'modified_date' => array(
 					'name' => 'modified_date',
-					'type' => CRM_Utils_Type::T_TIMESTAMP,
+					'type' => CRM_Utils_Type::T_DATE,
 					'title' => ts('Modified Date'),
 					'description' => 'When was the the civisocial user was created or modified or deleted.',
 					'required' => false,
@@ -255,7 +254,6 @@ class CRM_Civisocial_DAO_CivisocialUser extends CRM_Core_DAO {
 					'where' => 'civisocial_user.modified_date',
 					'headerPattern' => '',
 					'dataPattern' => '',
-					'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
 				),
 			);
 		}

--- a/sql/civisocial_install.sql
+++ b/sql/civisocial_install.sql
@@ -10,13 +10,13 @@ DROP TABLE IF EXISTS `civisocial_user`;
 
 CREATE TABLE `civisocial_user` (
      `id` int unsigned NOT NULL AUTO_INCREMENT  COMMENT 'Unique User ID',
-     `contact_id` int unsigned    COMMENT 'FK to Contact ID that owns that account',
-     `backend` varchar(128)    COMMENT 'Backend OAuth Provider',
-     `social_user_id` varchar(128) NULL  DEFAULT NULL COMMENT 'User ID for facebook, to be used to match friends etc.',
-     `access_token` varchar(511) NULL  DEFAULT NULL COMMENT 'Access Token Provided by OAuth Provider',
-     `oauth_object` varchar(1023) NULL  DEFAULT NULL COMMENT 'Access Token Provided by OAuth Provider',
-     `created_date` timestamp NULL  DEFAULT CURRENT_TIMESTAMP COMMENT 'When was the civisocial user was created.',
-     `modified_date` timestamp NULL  DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'When was the the civisocial user was created or modified or deleted.'
+     `contact_id` int unsigned NULL DEFAULT NULL COMMENT 'FK to Contact ID that owns that account',
+     `backend` varchar(128) NOT NULL COMMENT 'Backend OAuth Provider',
+     `social_user_id` varchar(128) NULL DEFAULT NULL COMMENT 'User ID for facebook, to be used to match friends etc.',
+     `access_token` varchar(512) NULL DEFAULT NULL COMMENT 'Access Token Provided by OAuth Provider',
+     `oauth_object` varchar(1024) NULL DEFAULT NULL COMMENT 'Access Token Provided by OAuth Provider',
+     `created_date` datetime NOT NULL COMMENT 'When was the civisocial user was created.',
+     `modified_date` datetime NOT NULL COMMENT 'When was the the civisocial user was created or modified or deleted.'
 , PRIMARY KEY ( `id` )
 , CONSTRAINT FK_civisocial_user_contact_id FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;


### PR DESCRIPTION
 - There can be only one TIMESTAMP column with CURRENT_TIMESTAMP in DEFAULT clause on MySQL versions earlier than 5.6. So, changed the code to manually store 'created_date` and `modified_date`
 - It makes more sense to store dates as DATETIME as it allows many calculations natively the need of which might arise in future.