### PR TITLE
Update OAuthProvider class's http() method and corresponding changes

### DIFF
--- a/CRM/Civisocial/OAuthProvider/Facebook.php
+++ b/CRM/Civisocial/OAuthProvider/Facebook.php
@@ -107,10 +107,6 @@ class CRM_Civisocial_OAuthProvider_Facebook extends CRM_Civisocial_OAuthProvider
     );
 
     $response = $this->get('oauth/access_token', $params);
-    if (isset($response['error'])) {
-      exit($response['error']);
-    }
-
     $this->token = CRM_Utils_Array::value('access_token', $response);
 
     // Check if all basic perimissions have been granted
@@ -227,22 +223,33 @@ class CRM_Civisocial_OAuthProvider_Facebook extends CRM_Civisocial_OAuthProvider
   }
 
   /**
-   * GET wrapper for Facebook HTTP request
+   * Appends an access token, makes HTTP request and handles the repsonse
    *
-   * @param string $node
-   *   API node
+   * @param string $url
+   *   Request URL
    * @param array $params
-   *   GET/POST parameters
+   *   Request parameters
    * @param string $method
-   *   HTTP method (GET/POST)
+   *   HTTP method
    *
    * @return array
    */
-  public function http($node, $params = array(), $method = 'GET') {
+  public function http($url, $method = 'GET', $postFields = array()) {
+    $params = array();
     if ($this->token) {
       $params['access_token'] = $this->token;
     }
-    $response = parent::http($node, $params, $method);
+    if (!empty($params)) {
+      if (FALSE !== strpos($url, '?')) {
+        $url .= '&';
+      }
+      else {
+        $url .= '?';
+      }
+      $url .= http_build_query($params);
+    }
+    $responseJson = parent::http($url, $method, $postFields);
+    $response = json_decode($responseJson, TRUE);
     if (isset($response['error'])) {
       if ($response['error']['type'] == 'OAuthException') {
         // Invalid access token

--- a/CRM/Civisocial/OAuthProvider/Facebook.php
+++ b/CRM/Civisocial/OAuthProvider/Facebook.php
@@ -105,7 +105,6 @@ class CRM_Civisocial_OAuthProvider_Facebook extends CRM_Civisocial_OAuthProvider
       'code' => CRM_Utils_Array::value('code', $_GET),
       'redirect_uri' => $this->getCallbackUri($this->alias),
     );
-
     $response = $this->get('oauth/access_token', $params);
     $this->token = CRM_Utils_Array::value('access_token', $response);
 
@@ -234,21 +233,11 @@ class CRM_Civisocial_OAuthProvider_Facebook extends CRM_Civisocial_OAuthProvider
    *
    * @return array
    */
-  public function http($url, $method = 'GET', $postFields = array()) {
-    $params = array();
+  public function http($url, $method, $postParams = array(), $getParams = array()) {
     if ($this->token) {
-      $params['access_token'] = $this->token;
+      $getParams['access_token'] = $this->token;
     }
-    if (!empty($params)) {
-      if (FALSE !== strpos($url, '?')) {
-        $url .= '&';
-      }
-      else {
-        $url .= '?';
-      }
-      $url .= http_build_query($params);
-    }
-    $responseJson = parent::http($url, $method, $postFields);
+    $responseJson = parent::http($url, $method, $postParams, $getParams);
     $response = json_decode($responseJson, TRUE);
     if (isset($response['error'])) {
       if ($response['error']['type'] == 'OAuthException') {

--- a/CRM/Civisocial/OAuthProvider/Googleplus.php
+++ b/CRM/Civisocial/OAuthProvider/Googleplus.php
@@ -110,11 +110,7 @@ class CRM_Civisocial_OAuthProvider_Googleplus extends CRM_Civisocial_OAuthProvid
       'grant_type' => 'authorization_code',
     );
 
-    $response = $this->http('token', $params, 'POST');
-    if (isset($response['error'])) {
-      exit($response['error']);
-    }
-
+    $response = $this->post('token', $params);
     $this->token = CRM_Utils_Array::value('access_token', $response);
 
     // Authentication is successful. Fetch user profile
@@ -187,22 +183,40 @@ class CRM_Civisocial_OAuthProvider_Googleplus extends CRM_Civisocial_OAuthProvid
   }
 
   /**
-   * GET wrapper for Google's HTTP request
+   * Appends an access token, makes HTTP request and handles the repsonse
+   *
    * @param string $node
-   *   API node
+   *   Request URL
    * @param array $params
-   *   GET/POST parameters
+   *   Request parameters
    * @param string $method
-   *   HTTP method (GET/POST)
+   *   HTTP method
    *
    * @return array
    */
-  public function http($node, $params = array(), $method = 'GET') {
+  public function http($url, $method = 'GET', $postFields = array()) {
+    $params = array();
     $params['alt'] = 'json';
     if ($this->token) {
       $params['access_token'] = $this->token;
     }
-    $response = parent::http($node, $params, $method);
+    // @todo: Create some method like `appendQueryString` in the base class
+    if ($method == 'GET') {
+      if (!empty($params)) {
+        if (FALSE !== strpos($url, '?')) {
+          $url .= '&';
+        }
+        else {
+          $url .= '?';
+        }
+        $url .= http_build_query($params);
+      }
+    }
+    else {
+      $postFields = array_merge($postFields, $params);
+    }
+    $responseJson = parent::http($url, $method, $postFields);
+    $response = json_decode($responseJson, TRUE);
     if (isset($response['error'])) {
       if ($response['error'] == 'invalid_token' || $response['error'] == 'invalid_request') {
         // Invalid access token

--- a/CRM/Civisocial/OAuthProvider/Googleplus.php
+++ b/CRM/Civisocial/OAuthProvider/Googleplus.php
@@ -194,28 +194,13 @@ class CRM_Civisocial_OAuthProvider_Googleplus extends CRM_Civisocial_OAuthProvid
    *
    * @return array
    */
-  public function http($url, $method = 'GET', $postFields = array()) {
-    $params = array();
-    $params['alt'] = 'json';
+  // public function http($url, $method = 'GET', $postParams = array()) {
+  public function http($url, $method, $postParams = array(), $getParams = array()) {
+    $getParams['alt'] = 'json';
     if ($this->token) {
-      $params['access_token'] = $this->token;
+      $getParams['access_token'] = $this->token;
     }
-    // @todo: Create some method like `appendQueryString` in the base class
-    if ($method == 'GET') {
-      if (!empty($params)) {
-        if (FALSE !== strpos($url, '?')) {
-          $url .= '&';
-        }
-        else {
-          $url .= '?';
-        }
-        $url .= http_build_query($params);
-      }
-    }
-    else {
-      $postFields = array_merge($postFields, $params);
-    }
-    $responseJson = parent::http($url, $method, $postFields);
+    $responseJson = parent::http($url, $method, $postParams, $getParams);
     $response = json_decode($responseJson, TRUE);
     if (isset($response['error'])) {
       if ($response['error'] == 'invalid_token' || $response['error'] == 'invalid_request') {

--- a/CRM/Civisocial/OAuthProvider/Twitter.php
+++ b/CRM/Civisocial/OAuthProvider/Twitter.php
@@ -151,8 +151,8 @@ class CRM_Civisocial_OAuthProvider_Twitter extends CRM_Civisocial_OAuthProvider 
     if ($this->token && isset($this->userProfile)) {
       return TRUE;
     }
-
-    $userProfile = $this->get('account/verify_credentials.json?include_email=true');
+    $getParams = array('include_email' => 'true' );
+    $userProfile = $this->get('account/verify_credentials', $getParams);
     if (200 == $this->httpCode) {
       $this->userProfile = $userProfile;
       return TRUE;
@@ -246,34 +246,36 @@ class CRM_Civisocial_OAuthProvider_Twitter extends CRM_Civisocial_OAuthProvider 
   }
 
   /**
-   * GET wrapper for oAuthRequest.
+   * GET wrapper for HTTP request
    *
-   * @param string $node
-   *   Twitter REST API node
-   * @param array $params
-   *   Parameters to REST API
+   * @param $node
+   *   API node
+   * @param $getParams
+   *   GET parameters
    *
    * @return array
-   *   Response from Twitter REST API
+   *   Response to API request
    */
-  public function get($node, $params = array()) {
-    $response = $this->oAuthRequest($node, 'GET', $params);
+  public function get($node, $getParams = array()) {
+    $response = $this->oAuthRequest($node, 'GET', $getParams);
     return json_decode($response, TRUE);
   }
 
   /**
-   * POST wrapper for oAuthRequest.
+   * POST wrapper for HTTP request
    *
    * @param string $node
-   *   Twitter REST API node
-   * @param array $params
-   *   Parameters to REST API
+   *   API node
+   * @param array $postParams
+   *   POST parameters
+   * @param array $getParams
+   *   To match base class's method declaration
    *
    * @return array
-   *   Response from Twitter REST API
+   *   Response to API request
    */
-  public function post($node, $params = array()) {
-    $response = $this->oAuthRequest($node, 'POST', $params);
+  public function post($node, $postParams = array(), $getParams = array()) {
+    $response = $this->oAuthRequest($node, 'POST', $postParams);
     return json_decode($response, TRUE);
   }
 


### PR DESCRIPTION
 - Now all OAuthProviders share base class's http() method. Twitter didn't before.
 - Made http() method even simpler adding a parameter `$getParams`. Now query strings are appended to URL directly on http() method of the base class
 - Fixed issue that was preventing the retrieval of email from Twitter
 - Updated code for more clarity
 - Added missing documentation