### PR TITLE
Update OAuthProvider class and it's child classes for more convenience

### DIFF
--- a/CRM/Civisocial/OAuthProvider/Facebook.php
+++ b/CRM/Civisocial/OAuthProvider/Facebook.php
@@ -125,6 +125,20 @@ class CRM_Civisocial_OAuthProvider_Facebook extends CRM_Civisocial_OAuthProvider
   }
 
   /**
+   * Check if the user is logged into Facebook
+   *
+   * @return bool
+   */
+  public function isLoggedIn() {
+    $session = CRM_Core_Session::singleton();
+    $oAuthProvider = $session->get('civisocial_oauth_provider');
+    if ($oAuthProvider && $oAuthProvider == $this->alias) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
    * Check if the user is connected to Facebook and authorized.
    * It can also be used to validate access tokens after setting one.
    *

--- a/CRM/Civisocial/OAuthProvider/Googleplus.php
+++ b/CRM/Civisocial/OAuthProvider/Googleplus.php
@@ -121,6 +121,20 @@ class CRM_Civisocial_OAuthProvider_Googleplus extends CRM_Civisocial_OAuthProvid
   }
 
   /**
+   * Check if the user is logged into Google Plus
+   *
+   * @return bool
+   */
+  public function isLoggedIn() {
+    $session = CRM_Core_Session::singleton();
+    $oAuthProvider = $session->get('civisocial_oauth_provider');
+    if ($oAuthProvider && $oAuthProvider == $this->alias) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
    * Check if the user is connected to Google and authorized.
    * It can also be used to validate access tokens after setting one.
    *

--- a/CRM/Civisocial/OAuthProvider/Twitter.php
+++ b/CRM/Civisocial/OAuthProvider/Twitter.php
@@ -93,6 +93,20 @@ class CRM_Civisocial_OAuthProvider_Twitter extends CRM_Civisocial_OAuthProvider 
   }
 
   /**
+   * Check if the user is logged into Twitter
+   *
+   * @return bool
+   */
+  public function isLoggedIn() {
+    $session = CRM_Core_Session::singleton();
+    $oAuthProvider = $session->get('civisocial_oauth_provider');
+    if ($oAuthProvider && $oAuthProvider == $this->alias) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
    * Get if the user is connected to OAuth provider and authorized
    *
    * @return bool
@@ -118,6 +132,17 @@ class CRM_Civisocial_OAuthProvider_Twitter extends CRM_Civisocial_OAuthProvider 
       return TRUE;
     }
     return FALSE;
+  }
+
+  /**
+   * Set Access Token to the current OAuthProvider object to be able to make
+   * API requests. Validity of the passed access token should be checked
+   * using isAuthorized() method.
+   *
+   * @param array $accessToken
+   */
+  public function setAccessToken($accessToken) {
+    $this->token = new OAuthConsumer($accessToken['oauth_token'], $accessToken['oauth_token_secret']);
   }
 
   /**


### PR DESCRIPTION
 - All child classes override isLoggedIn(). Eg. Facebook's isLoggedIn() checks
   if the user is connected to Facebook. OAuthProvider's isLoggedIn() returns
   the alias of the OAuth provider the user is logged in to. It returns FALSE
   if the user is not connected to any the OAuth providers.

 - Added new method saveRedirect() to OAuthProvider class.

 - Added new method setAccessToken() to OAuthProvider class. Now token can be
   assigned to the OAuthProvider object after it has been constructed. 

   Eg. If we are interested on Facebook API only:

   ```
   $facebook = new CRM_Civisocial_OAuthProvider_Facebook();
    if ($facebook->isLoggedIn()) {
      $facebook->setAccessToken($session->get('access_token'));
      if ($facebook->isAuthorized()) {
       	// API requests with $facebook eg. $facebook->get(me);
      }
    }

    $currentUrl = CRM_Utils_System::url(ltrim($_SERVER['REQUEST_URI'], '/'), NULL, TRUE, NULL, FALSE));
    $facebook->saveRedirect($currentUrl);
    CRM_Utils_System::redirect($facebook->getLoginUri());
    ```