### PR TITLE
Facebook Event Integration

### DIFF
--- a/CRM/Civisocial/OAuthProvider/Facebook.php
+++ b/CRM/Civisocial/OAuthProvider/Facebook.php
@@ -190,6 +190,7 @@ class CRM_Civisocial_OAuthProvider_Facebook extends CRM_Civisocial_OAuthProvider
     if (count($permissions) > count($grantedPermissions)) {
       return FALSE;
     }
+    CRM_Core_Error::debug_var('grantedPermissions', $grantedPermissions);
     return array_diff($permissions, $grantedPermissions);
   }
 

--- a/CRM/Civisocial/Page/Facebook/RSVPEvent.php
+++ b/CRM/Civisocial/Page/Facebook/RSVPEvent.php
@@ -2,7 +2,7 @@
 /**
  * Sets the RSVP to "Going" on a corresponding Facbeook event.
  */
-class CRM_Civisocial_Page_RSVPFacebookEvent extends CRM_Core_Page {
+class CRM_Civisocial_Page_Facebook_RSVPEvent extends CRM_Core_Page {
 
   public function run() {
     $session = CRM_Core_Session::singleton();

--- a/templates/CRM/Civisocial/Form/Settings/SocialNetworks.tpl
+++ b/templates/CRM/Civisocial/Form/Settings/SocialNetworks.tpl
@@ -1,9 +1,17 @@
 <div class="crm-block crm-form-block crm-date-form-block civisocial-wrapper">
   <div class="civisocial-box">
     <div class="help">
-      Use this screen to connect to your organization's accounts on social networks for social insight and other features.
+      Use this screen to connect to your organization's accounts on social networks for social insight, facebook event integration and other features.
     </div>
   </div>
+
+  {* Facebook Events Section *}
+  <div class="civisocial-box">
+    <div class="box-item">
+      <label class="input">{$form.integrate_facebook_events.html} Integrate Facebook events</label>
+    </div>
+  </div>
+  {* End Facebook Events Section *}
 
   {* Facebook Section *}
   <div class="civisocial-box">
@@ -18,16 +26,13 @@
           <div><a href="{crmURL p='civicrm/admin/civisocial/network/disconnect/facebookpage'}?continue={$currentUrl}">Disconnect</a></div>
         </div>
       </div>
-      <div class="spacer"></div>
-      <div class="box-item">
-        <label class="input">{$form.integrate_facebook_events.html} Integrate Facebook events</label>
-      </div>
     {else}
       <div class="crm-section">
           <a class="btn btn-facebook bg-facebook" href="{crmURL p='civicrm/admin/civisocial/network/connect/facebookpage'}?continue={$currentUrl}">Connect Facebook Page</a>
       </div>
     {/if}
   </div>
+  {* End Facebook Section *}
 
   {* Twitter Section *}
   <div class="civisocial-box">
@@ -48,3 +53,4 @@
       </div>
     {/if}
   </div>
+  {* End Twitter Section *}

--- a/templates/FacebookEventIdField.tpl
+++ b/templates/FacebookEventIdField.tpl
@@ -1,3 +1,0 @@
-<script type="text/javascript">
-  cj('<tr><td class="label">{$form.facebook_event_id.label}</td><td>{$form.facebook_event_id.html|crmAddClass:huge}<br/><span class="description">{ts}https://www.facebook.com/events/[Facebook Event Id]<br/>You can paste event URL too.{/ts}</span></td></tr>').insertAfter('tr.crm-event-manage-eventinfo-form-block-title');
-</script>

--- a/templates/OAuthProvider/Facebook/FacebookEventURLField.tpl
+++ b/templates/OAuthProvider/Facebook/FacebookEventURLField.tpl
@@ -1,0 +1,7 @@
+<script type="text/javascript">
+{if $fbEventEnabled eq '1'}
+  cj('<tr><td class="label">{$form.facebook_event_url.label}</td><td>{$form.facebook_event_url.html|crmAddClass:huge}<br/><span class="description">{ts}Please ensure that the Facebook event is public.{/ts}</span></td></tr>').insertAfter('tr.crm-event-manage-eventinfo-form-block-title');
+{else}
+  cj('<div class="help"><a href="{crmURL p="civicrm/admin/civisocial/networks"}">Connect Facebook page</a> to integrate Facebook event.</div>').insertBefore('.crm-block table');    
+{/if}
+</script>

--- a/templates/OAuthProvider/Facebook/FacebookEventURLField.tpl
+++ b/templates/OAuthProvider/Facebook/FacebookEventURLField.tpl
@@ -1,7 +1,34 @@
-<script type="text/javascript">
 {if $fbEventEnabled eq '1'}
-  cj('<tr><td class="label">{$form.facebook_event_url.label}</td><td>{$form.facebook_event_url.html|crmAddClass:huge}<br/><span class="description">{ts}Please ensure that the Facebook event is public.{/ts}</span></td></tr>').insertAfter('tr.crm-event-manage-eventinfo-form-block-title');
-{else}
-  cj('<div class="help"><a href="{crmURL p="civicrm/admin/civisocial/networks"}">Connect Facebook page</a> to integrate Facebook event.</div>').insertBefore('.crm-block table');    
+  {if $fbConnected eq '1'}
+    <table style="display: none;">
+      <tr id='facebook_event_url_row'>
+        <td class="label">{$form.facebook_event_url.label}</td>
+        <td>{$form.facebook_event_url.html|crmAddClass:huge}
+          <!-- <a id="fetch_fb_event_info" href="javascript:void(0);">Fetch Info</a><br/> -->
+          <span class="description"><br/>{ts}Please ensure that the Facebook event is public.{/ts}</span>
+        </td>
+      </tr>
+    </table>
+  {else}
+    <div id="integrate-facebook" class="help">
+      <a href="{crmURL p="civicrm/civisocial/login/facebook"}?continue={$currentUrl}">Login with Facebook</a> to integrate Facebook event.
+    </div>
+  {/if}
 {/if}
-</script>
+{literal}
+  <script type="text/javascript">
+{/literal}
+{if $fbEventEnabled eq '1'}
+  {if $fbConnected eq '1'}
+    {literal}
+      cj('tr#facebook_event_url_row').insertAfter('tr.crm-event-manage-eventinfo-form-block-title');
+    {/literal}
+  {else}
+    {literal}
+      cj('div#integrate-facebook').insertBefore('.crm-block table');    
+    {/literal}
+  {/if}
+{/if}
+{literal}
+  </script> 
+{/literal}

--- a/templates/OAuthProvider/Facebook/RegistrationConfirm.tpl
+++ b/templates/OAuthProvider/Facebook/RegistrationConfirm.tpl
@@ -1,13 +1,15 @@
+<div id="fb-event-rsvp-option">
+  <div class="spacer"></div>
+  <div class="crm-group">
+    <div class="header-dark">Facebook</div>
+    <div class="crm-section no-label">
+      <div class="content"><input type="checkbox" name="facebook_rsvp_event" checked="checked"> {$form.facebook_rsvp_event.label}</div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+</div>
+{literal}
 <script type="text/javascript">
-  var html = '' +
-    '<div class="spacer"></div>' +
-    '<div class="crm-group">' +
-      '<div class="header-dark">Facebook</div>' +
-      '<div class="crm-section no-label">' +
-        '<div class="content"><input type="checkbox" name="facebook_rsvp_event" checked="checked"> {$form.facebook_rsvp_event.label}</div>' +
-      '</div>' +
-    '</div>' +
-    '<div class="spacer"></div>' +
-  	'';
-  cj(html).insertBefore('div.continue_message-section');
+  cj('div#fb-event-rsvp-option').insertBefore('div.continue_message-section');
 </script>
+{/literal}

--- a/templates/OAuthProvider/Facebook/RegistrationThankYou.tpl
+++ b/templates/OAuthProvider/Facebook/RegistrationThankYou.tpl
@@ -1,15 +1,17 @@
+<div id="fb-event-rsvp-status">  
+  <div class="spacer"></div>
+    <div class="crm-group">
+      <div class="header-dark">Facebook</div>
+      <div class="crm-section no-label">
+        <div class="content">
+          Going to <a href="{$facebook_event_url}">{$facebook_event_name}</a>
+        </div>
+      </div>
+    </div>
+    <div class="spacer"></div>
+</div>
+{literal}
 <script type="text/javascript">
-  var html = '' +
-    '<div class="spacer"></div>' +
-    '<div class="crm-group">' +
-      '<div class="header-dark">Facebook</div>' +
-      '<div class="crm-section no-label">' +
-        '<div class="content">' +
-          'Going to <a href="{$facebook_event_url}">{$facebook_event_name}</a>' +
-        '</div>' +
-      '</div>' +
-    '</div>' +
-    '<div class="spacer"></div>' +
-  	'';
-  cj(html).insertBefore('#footer_text');
+  cj('div#fb-event-rsvp-status').insertBefore('#footer_text');
 </script>
+{/literal}

--- a/templates/res/js/facebook-event.js
+++ b/templates/res/js/facebook-event.js
@@ -1,11 +1,13 @@
 CRM.$(function($) {
 	// Extract the event ID if the event URL is given
-	cj('#facebook_event_id').change(function() {
+	cj('#facebook_event_url').change(function() {
 		var eventUrl = cj(this).val();
-	    var eventId = eventUrl.match(/facebook\.com\/events\/([0-9]+)\/?/m);
-	    if (eventId) {
-	      cj(this).val(eventId[1]);
-	    }
+    var matches = eventUrl.match(/(((https|http):\/\/)?(www.)?facebook.com\/events\/[0-9]*(\/)?).*/m);
+    if (matches) {
+      cj(this).val(matches[1]);
+    } else {
+    	cj(this).val('');
+    }
 	});
 
 });

--- a/templates/res/js/facebook-event.js
+++ b/templates/res/js/facebook-event.js
@@ -1,13 +1,3 @@
 CRM.$(function($) {
-	// Extract the event ID if the event URL is given
-	cj('#facebook_event_url').change(function() {
-		var eventUrl = cj(this).val();
-    var matches = eventUrl.match(/(((https|http):\/\/)?(www.)?facebook.com\/events\/[0-9]*(\/)?).*/m);
-    if (matches) {
-      cj(this).val(matches[1]);
-    } else {
-    	cj(this).val('');
-    }
-	});
 
 });

--- a/xml/Menu/civisocial.xml
+++ b/xml/Menu/civisocial.xml
@@ -35,7 +35,7 @@
   </item>
   <item>
     <path>civicrm/civisocial/event/rsvpfacebookevent</path>
-    <page_callback>CRM_Civisocial_Page_RSVPFacebookEvent</page_callback>
+    <page_callback>CRM_Civisocial_Page_Facebook_RSVPEvent</page_callback>
     <title>RSVP on Facebook</title>
     <access_callback>1</access_callback>
     <is_public>true</is_public>
@@ -69,12 +69,5 @@
     <page_callback>CRM_Civisocial_Page_Twitter_Disconnect</page_callback>
     <title>Disconnect Twitter</title>
     <access_arguments>administer CiviCRM</access_arguments>
-  </item>
-  <item>
-    <path>civicrm/civisocial/test</path>
-    <page_callback>CRM_Civisocial_Page_Test</page_callback>
-    <title>Test</title>
-    <access_callback>1</access_callback>
-    <is_public>true</is_public>
   </item>
 </menu>


### PR DESCRIPTION
- Now Facebook Event option in Add New event page will only be visible if the
page is connected and 'Integrate Facebook Events' option is enabled.
- Added check if facebook event exists while adding the Facebook Event URL
- Refactor template files to avoid parsing errors
- Other corresponding changes